### PR TITLE
Fixed speedbrake not completly disabled with { key

### DIFF
--- a/Nasal/systems.nas
+++ b/Nasal/systems.nas
@@ -503,7 +503,7 @@ setlistener("controls/flight/speedbrake", func(spd_brake){
 
 setlistener("controls/flight/speedbrake-lever", func(spd_lever){
     var lever = spd_lever.getValue();
-    if (lever>1)
+    if (lever>=1)
     {
         setprop("controls/flight/speedbrake", (lever - 1));
     }


### PR DESCRIPTION
When disabling the speedbrakes using the keyboard, the lever
is correctly moved to the ARMED position, but
/controls/flight/speedbrake remains at 0.01, prompting
SPEEDBRAKE EXTENDED waening at approach.